### PR TITLE
Style dynamique des cartes ETF

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,11 +1,14 @@
 /* Style global pour les « cartes » ETF */
 .card {
-  border: 2px solid #1f77b4 !important;
-  border-radius: 6px !important;
-  padding: 12px !important;
-  margin: 6px !important;
+  border: 2px solid;
+  border-radius: 8px;
+  padding: 12px;
+  margin: 8px 0;
+  background-color: #ffffff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
 /* Pour réduire le padding interne des conteneurs Streamlit */
 .card .stContainer {
-  padding: 0 !important;
+  padding: 0;
 }

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,7 +8,7 @@ from constants       import ETFS, TIMEFRAMES, MACRO_SERIES
 from data_loader     import load_prices, load_macro
 from scoring         import pct_change, score_and_style
 from plotting        import make_timeseries_fig
-from streamlit_utils import inject_css, begin_card, end_card
+from streamlit_utils import inject_css, begin_card, end_card, get_border_color
 
 # --- CONFIGURATION DE LA PAGE ---
 st.set_page_config(
@@ -82,19 +82,38 @@ for idx, (name, series) in enumerate(prices.items()):
     # Graphique Plotly
     fig = make_timeseries_fig(data, period)
 
-    # Allocation & couleur de bordure (on met en rouge ici pour reproduire votre screenshot)
-    alloc_pct   = allocations[name]
-    border_color = "crimson"  # ou calculez via get_border_color(alloc_pct)
+    # Allocation & couleur de bordure
+    alloc_pct    = allocations[name]
+    border_color = get_border_color(alloc_pct)
 
     # --- CARTE COMPLÈTE ---
     with cols[idx % 2]:
         begin_card(border_color)
 
-        # Titre + variation %
+        # Titre
         st.markdown(
-            f"**{name}: {last:.2f} "
-            f"<span style='color:{perf_color}'>{delta:+.2f}%</span>**",
-            unsafe_allow_html=True
+            f"<div style='font-size:20px;font-family:sans-serif;'>{name}</div>",
+            unsafe_allow_html=True,
+        )
+
+        # Dernier cours
+        st.markdown(
+            f"<div style='font-size:14px;font-family:sans-serif;'>Dernier cours : {last:.2f}</div>",
+            unsafe_allow_html=True,
+        )
+
+        # Tendance
+        arrow = "↑" if delta > 0 else "↓" if delta < 0 else "→"
+        st.markdown(
+            f"<div style='font-size:14px;font-family:sans-serif;'>Tendance : "
+            f"<span style='color:{perf_color}'>{arrow} {delta:+.2f}%</span></div>",
+            unsafe_allow_html=True,
+        )
+
+        # Allocation
+        st.markdown(
+            f"<div style='font-size:14px;font-family:sans-serif;'>Allocation : {alloc_pct:.1f}%</div>",
+            unsafe_allow_html=True,
         )
 
         # Chart

--- a/streamlit_utils.py
+++ b/streamlit_utils.py
@@ -1,31 +1,72 @@
 # -*- coding: utf-8 -*-
+"""Utilitaires d'interface pour l'application Streamlit.
+
+Ces helpers permettent d'injecter une feuille de style commune et de
+faciliter la création de conteneurs "carte" au style homogène.
 """
-Helpers Streamlit : wrapper pour encadrer tout un bloc dans une “carte” HTML.
-"""
+
+from __future__ import annotations
 
 import streamlit as st
 
-def inject_css():
-    """
-    (Optionnel) CSS global, ici non utilisé car on passe tout en inline.
-    """
-    pass
 
-def begin_card(border_color: str = "crimson"):
+def inject_css() -> None:
+    """Charge `css/styles.css` et l'injecte dans la page Streamlit.
+
+    Si le fichier n'est pas trouvé, l'application continue de fonctionner
+    sans interrompre l'utilisateur.
     """
-    Ouvre un <div> avec une bordure de 3px et un border-radius de 6px,
-    de la couleur passée en paramètre.
-    Tout le contenu suivant sera à l’intérieur de cette carte jusqu’à end_card().
+
+    try:
+        with open("css/styles.css", "r", encoding="utf-8") as f:
+            css = f.read()
+        st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+    except OSError:
+        # Fichier de style absent : on ignore silencieusement
+        pass
+
+
+def get_border_color(pct: float) -> str:
+    """Retourne une couleur de bordure selon la pondération.
+
+    Les seuils sont volontairement simples pour offrir trois niveaux de
+    lecture : rouge pour une faible pondération, jaune pour une
+    pondération intermédiaire et vert pour une forte pondération.
+
+    Parameters
+    ----------
+    pct: float
+        La pondération (en %).
+
+    Returns
+    -------
+    str
+        Une couleur CSS.
     """
+
+    if pct >= 40:
+        return "green"
+    if pct >= 20:
+        return "gold"
+    return "crimson"
+
+
+def begin_card(border_color: str = "crimson") -> None:
+    """Ouvre un conteneur 'carte' avec une bordure colorée.
+
+    Les styles principaux (padding, marges, ombre, etc.) sont définis dans la
+    feuille `css/styles.css`. Ici, on ne fait que surcharger la couleur de la
+    bordure pour refléter l'état de l'ETF.
+    """
+
     st.markdown(
-        f"<div style='"
-        f"border:3px solid {border_color};"
-        f"border-radius:6px;"
-        f"padding:12px;"
-        f"margin:12px 0;'>",
-        unsafe_allow_html=True
+        f"<div class='card' style='border-color:{border_color};'>",
+        unsafe_allow_html=True,
     )
 
-def end_card():
-    """Ferme la <div> de la carte."""
+
+def end_card() -> None:
+    """Ferme le conteneur de la carte précédemment ouvert."""
+
     st.markdown("</div>", unsafe_allow_html=True)
+


### PR DESCRIPTION
## Summary
- Affichage des cartes ETF avec entête structuré et bordure colorée suivant la pondération
- Ajout d'un utilitaire `get_border_color` pour traduire une pondération en couleur
- Feuille de style CSS ajustée pour laisser la bordure gérée dynamiquement

## Testing
- `pytest -q` *(ModuleNotFoundError: No module named 'dca_dashboard')*

------
https://chatgpt.com/codex/tasks/task_e_68a6242939e0832784b712a8e6a99416