### PR TITLE
Refactor card handling with context manager

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,8 +1,10 @@
 /* Style global pour les « cartes » ETF */
 .card {
-  border: 2px solid #1f77b4 !important;
+  border: 2px solid !important;
   border-radius: 6px !important;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
   padding: 12px !important;
+  background-color: #fff !important;
   margin: 6px !important;
 }
 /* Pour réduire le padding interne des conteneurs Streamlit */

--- a/streamlit_utils.py
+++ b/streamlit_utils.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-Helpers Streamlit : wrapper pour encadrer tout un bloc dans une “carte” HTML.
+Helpers Streamlit : gestionnaire de contexte pour encadrer un bloc dans une "carte" HTML.
 """
 
 import streamlit as st
+from contextlib import contextmanager
+
 
 def inject_css():
     """
@@ -11,21 +13,16 @@ def inject_css():
     """
     pass
 
-def begin_card(border_color: str = "crimson"):
-    """
-    Ouvre un <div> avec une bordure de 3px et un border-radius de 6px,
-    de la couleur passée en paramètre.
-    Tout le contenu suivant sera à l’intérieur de cette carte jusqu’à end_card().
-    """
-    st.markdown(
-        f"<div style='"
-        f"border:3px solid {border_color};"
-        f"border-radius:6px;"
-        f"padding:12px;"
-        f"margin:12px 0;'>",
-        unsafe_allow_html=True
-    )
 
-def end_card():
-    """Ferme la <div> de la carte."""
-    st.markdown("</div>", unsafe_allow_html=True)
+@contextmanager
+def card(border_color: str):
+    """Encapsule le contenu du bloc dans une carte avec la couleur de bordure fournie."""
+    c = st.container()
+    c.markdown(
+        f"<div class='card' style='border-color:{border_color};'>",
+        unsafe_allow_html=True,
+    )
+    try:
+        yield c
+    finally:
+        c.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- replace begin/end card helpers with `card` context manager
- wrap ETF card content in container-aware context usage
- refine CSS card style with border, shadow, padding and background

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'dca_dashboard')*

------
https://chatgpt.com/codex/tasks/task_e_68a63e647d5483278b9e06fc47ccd726