### PR TITLE
Remove container borders and use internal card styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,5 @@
 /* Style global pour les « cartes » ETF */
 .card {
-  border: 2px solid #1f77b4 !important;
   border-radius: 6px !important;
   padding: 12px !important;
   margin: 6px !important;


### PR DESCRIPTION
## Summary
- drop static border on `.card` style
- wrap ETF sections with `st.container` and apply border via card helper

## Testing
- `pytest -q` *(fails: No module named 'dca_dashboard')*

------
https://chatgpt.com/codex/tasks/task_e_68a71022f6ec83278814678d7a01eb51